### PR TITLE
Refreshes Twitch token before checking status

### DIFF
--- a/app/Console/Commands/CheckTwitchLiveStatus.php
+++ b/app/Console/Commands/CheckTwitchLiveStatus.php
@@ -6,7 +6,6 @@ use App\Enums\ConnectionType;
 use App\Livewire\Actions\Api\Twitch\RefreshToken;
 use App\Models\User;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -18,7 +17,11 @@ class CheckTwitchLiveStatus extends Command
 
     public function handle(): int
     {
-        $token = User::first()->connections->firstWhere('type_id', ConnectionType::TWITCH->value)->token ?? null;
+        $user = User::first();
+
+        (new RefreshToken)->handle($user);
+
+        $token = $user->connections->firstWhere('type_id', ConnectionType::TWITCH->value)->token ?? null;
 
         if (! $token) {
             return self::FAILURE;

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Console\Commands\CheckTwitchLiveStatus;
-use App\Console\Commands\RefreshTwitchAccessToken;
 use Illuminate\Support\Facades\Schedule;
 use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
 
@@ -13,6 +12,4 @@ Schedule::command('model:prune', [
     ],
 ])->daily();
 
-Schedule::command(RefreshTwitchAccessToken::class)->monthly();
-
-Schedule::command(CheckTwitchLiveStatus::class)->everyMinute();
+Schedule::command(CheckTwitchLiveStatus::class)->everyFiveMinutes();


### PR DESCRIPTION
Ensures the Twitch access token is refreshed before checking the live status to prevent API authentication errors.

Increases the check frequency to every five minutes.

Removes unused schedule command.