### PR TITLE
Fetch latest resume for navigation component

### DIFF
--- a/app/Livewire/Navigation.php
+++ b/app/Livewire/Navigation.php
@@ -12,7 +12,10 @@ class Navigation extends Component
     public function render()
     {
         return view('navigation', [
-            'resume' => Asset::where('type_id', Asset::RESUME)->first()?->slug
+            'resume' => Asset::query()
+                ->where('type_id', Asset::RESUME)
+                ->latest()
+                ->first()?->slug
         ]);
     }
 


### PR DESCRIPTION
The `Asset` query for the resume link now includes `->latest()`. This ensures that if multiple resume assets exist in the database, the most recently created or updated resume is always used in the navigation, preventing links to outdated versions.