### PR TITLE
chore: Make ide-helper:models execution conditional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi",
-            "@php artisan ide-helper:models --nowrite --no-interaction --ansi"
+            "@php -r \"file_exists('vendor/barryvdh/laravel-ide-helper') && passthru('php artisan ide-helper:models --nowrite --no-interaction --ansi');\""
         ],
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force",


### PR DESCRIPTION
Ensures the `ide-helper:models` command only runs if the `barryvdh/laravel-ide-helper` package is installed. This prevents errors during `composer install --no-dev` or in environments where the package might be absent.