### PR TITLE
fix(media): Migrate type column to string-backed enum

### DIFF
--- a/app/Actions/Api/SearchMedia.php
+++ b/app/Actions/Api/SearchMedia.php
@@ -24,7 +24,7 @@ final class SearchMedia
         ]);
 
         if ($response->successful()) {
-            $existingMedia = Media::where('type_id', $mediaType)->pluck('media_id')->toArray();
+            $existingMedia = Media::where('type', $mediaType)->pluck('media_id')->toArray();
 
             return collect($response->json('results'))->map(function ($media) use ($existingMedia, $mediaType) {
                 if (in_array($media['id'], $existingMedia)) {
@@ -32,7 +32,7 @@ final class SearchMedia
                 }
 
                 return [
-                    'type_id' => $mediaType,
+                    'type' => $mediaType,
                     'media_id' => $media['id'],
                     'name' => $mediaType->value == MediaType::MOVIE->value ? $media['original_title'] : $media['original_name'],
                     'cover' => 'https://image.tmdb.org/t/p/original'.$media['poster_path'],

--- a/app/Actions/Api/Spotify/SearchArtist.php
+++ b/app/Actions/Api/Spotify/SearchArtist.php
@@ -26,7 +26,7 @@ final class SearchArtist
 
         if ($response->successful()) {
             $artists = Media::query()
-                ->where('type_id', MediaType::ARTIST->value)
+                ->where('type', MediaType::ARTIST->value)
                 ->pluck('media_id')
                 ->toArray();
 
@@ -38,7 +38,7 @@ final class SearchArtist
                 }
 
                 return [
-                    'type_id' => MediaType::ARTIST->value,
+                    'type' => MediaType::ARTIST->value,
                     'media_id' => $artist['id'],
                     'name' => $artist['name'],
                     'cover' => $cover,

--- a/app/Actions/Api/Spotify/SearchTrack.php
+++ b/app/Actions/Api/Spotify/SearchTrack.php
@@ -27,7 +27,7 @@ final class SearchTrack
 
         if ($response->successful()) {
             $tracks = Media::query()
-                ->where('type_id', MediaType::TRACK->value)
+                ->where('type', MediaType::TRACK->value)
                 ->pluck('media_id')
                 ->toArray();
 
@@ -39,7 +39,7 @@ final class SearchTrack
                 }
 
                 return [
-                    'type_id' => MediaType::TRACK->value,
+                    'type' => MediaType::TRACK->value,
                     'media_id' => $track['id'],
                     'name' => $track['name'],
                     'cover' => $cover,

--- a/app/Actions/Api/Twitch/SearchCategories.php
+++ b/app/Actions/Api/Twitch/SearchCategories.php
@@ -24,7 +24,7 @@ final class SearchCategories
         ]);
 
         if ($response->successful()) {
-            $games = Media::where('type_id', $mediaType->value)->pluck('media_id')->toArray();
+            $games = Media::where('type', $mediaType->value)->pluck('media_id')->toArray();
 
             return collect($response->json('data'))->map(function ($game) use ($games, $mediaType) {
                 if (in_array($game['id'], $games)) {
@@ -32,7 +32,7 @@ final class SearchCategories
                 }
 
                 return [
-                    'type_id' => $mediaType->value,
+                    'type' => $mediaType->value,
                     'media_id' => $game['id'],
                     'name' => $game['name'],
                     'cover' => $this->fix_box_art($game['box_art_url']),

--- a/app/Console/Commands/UpdateArtistImages.php
+++ b/app/Console/Commands/UpdateArtistImages.php
@@ -24,7 +24,7 @@ class UpdateArtistImages extends Command
 
         /* Loop through every artist in chunks of 50 and attempt to update their image. */
         Media::query()
-            ->where('type_id', MediaType::ARTIST->value)
+            ->where('type', MediaType::ARTIST->value)
             ->get()
             ->chunk(50)
             ->each(function ($chunk) use ($user) {

--- a/app/Enums/MediaType.php
+++ b/app/Enums/MediaType.php
@@ -2,13 +2,13 @@
 
 namespace App\Enums;
 
-enum MediaType: int
+enum MediaType: string
 {
-    case MOVIE = 1;
-    case TV = 2;
-    case ARTIST = 3;
-    case TRACK = 4;
-    case VIDEO_GAME = 5;
+    case MOVIE = 'movie';
+    case TV = 'tv';
+    case ARTIST = 'artist';
+    case TRACK = 'track';
+    case VIDEO_GAME = 'video_game';
 
     public function label(): string
     {

--- a/app/Livewire/Forms/MediaForm.php
+++ b/app/Livewire/Forms/MediaForm.php
@@ -15,7 +15,7 @@ class MediaForm extends Form
         $states = collect($this->states);
 
         Media::create([
-            'type_id' => $media['type_id'],
+            'type' => $media['type'],
             'media_id' => $media['media_id'],
             'name' => $media['name'],
             'cover' => $media['cover'],

--- a/app/Livewire/Media/Games/Edit.php
+++ b/app/Livewire/Media/Games/Edit.php
@@ -40,7 +40,7 @@ class Edit extends Component
     public function games()
     {
         return Media::query()
-            ->where('type_id', MediaType::VIDEO_GAME->value)
+            ->where('type', MediaType::VIDEO_GAME->value)
             ->when($this->search != '', fn (Builder $query) => $query->where('name', 'LIKE', "%$this->search%"))
             ->tap(fn ($query) => $this->sortBy ? $query->orderBy($this->sortBy, $this->sortDirection) : $query)
             ->paginate($this->perPage);

--- a/app/Livewire/Media/Games/Show.php
+++ b/app/Livewire/Media/Games/Show.php
@@ -18,23 +18,23 @@ class Show extends Component
     {
         return view('livewire.pages.media.games.show', [
             'favorites' => Media::query()
-                ->where('type_id', MediaType::VIDEO_GAME->value)
+                ->where('type', MediaType::VIDEO_GAME->value)
                 ->where('is_favorite', true)
                 ->paginate(27, pageName: 'favorites'),
             'current' => Media::query()
-                ->where('type_id', MediaType::VIDEO_GAME->value)
+                ->where('type', MediaType::VIDEO_GAME->value)
                 ->where('is_active', true)
                 ->paginate(27, pageName: 'currentlyPlaying'),
             'backlog' => Media::query()
-                ->where('type_id', MediaType::VIDEO_GAME->value)
+                ->where('type', MediaType::VIDEO_GAME->value)
                 ->where('in_backlog', true)
                 ->paginate(27, pageName: 'backlog'),
             'playedBefore' => Media::query()
-                ->where('type_id', MediaType::VIDEO_GAME->value)
+                ->where('type', MediaType::VIDEO_GAME->value)
                 ->where('is_completed', true)
                 ->paginate(27, pageName: 'playedBefore'),
             'completed' => Media::query()
-                ->where('type_id', MediaType::VIDEO_GAME->value)
+                ->where('type', MediaType::VIDEO_GAME->value)
                 ->where('data->total_completion', true)
                 ->paginate(27, pageName: 'totalCompletion'),
             'panel' => Panel::where('name', 'video_games')->first()->content,

--- a/app/Livewire/Media/Movies/Edit.php
+++ b/app/Livewire/Media/Movies/Edit.php
@@ -38,7 +38,7 @@ class Edit extends Component
     public function medias()
     {
         return Media::query()
-            ->where('type_id', MediaType::MOVIE->value)
+            ->where('type', MediaType::MOVIE->value)
             ->when($this->search != '', fn (Builder $query) => $query->where('name', 'LIKE', "%$this->search%"))
             ->tap(fn ($query) => $this->sortBy ? $query->orderBy($this->sortBy, $this->sortDirection) : $query)
             ->paginate($this->perPage);

--- a/app/Livewire/Media/Movies/Show.php
+++ b/app/Livewire/Media/Movies/Show.php
@@ -18,15 +18,15 @@ class Show extends Component
     {
         return view('livewire.pages.media.movies.show', [
             'favorites' => Media::query()
-                ->where('type_id', MediaType::MOVIE->value)
+                ->where('type', MediaType::MOVIE->value)
                 ->where('is_favorite', true)
                 ->paginate(27, pageName: 'favorites'),
             'backlog' => Media::query()
-                ->where('type_id', MediaType::MOVIE->value)
+                ->where('type', MediaType::MOVIE->value)
                 ->where('in_backlog', true)
                 ->paginate(27, pageName: 'backlog'),
             'completed' => Media::query()
-                ->where('type_id', MediaType::MOVIE->value)
+                ->where('type', MediaType::MOVIE->value)
                 ->where('is_completed', true)
                 ->paginate(27, pageName: 'completed'),
             'panel' => Panel::where('name', 'movies')->first()->content,

--- a/app/Livewire/Media/Music/Edit.php
+++ b/app/Livewire/Media/Music/Edit.php
@@ -42,7 +42,7 @@ class Edit extends Component
     public function artists()
     {
         return Media::query()
-            ->where('type_id', MediaType::ARTIST)
+            ->where('type', MediaType::ARTIST->value)
             ->when($this->searchArtists != '', fn (Builder $query) => $query->where('name', 'LIKE', "%$this->searchArtists%"))
             ->tap(fn ($query) => $this->sortBy ? $query->orderBy($this->sortBy, $this->sortDirection) : $query)
             ->paginate($this->perPageArtists);
@@ -52,7 +52,7 @@ class Edit extends Component
     public function tracks()
     {
         return Media::query()
-            ->where('type_id', MediaType::TRACK)
+            ->where('type', MediaType::TRACK->value)
             ->when($this->searchTracks != '', fn (Builder $query) => $query->where('name', 'LIKE', "%$this->searchTracks%"))
             ->tap(fn ($query) => $this->sortBy ? $query->orderBy($this->sortBy, $this->sortDirection) : $query)
             ->paginate($this->perPage);
@@ -78,7 +78,7 @@ class Edit extends Component
         $selectedMedia = collect($this->searchedMedia)->firstWhere('media_id', $mediaId);
 
         $media = Media::create([
-            'type_id' => $selectedMedia['type_id'],
+            'type' => $selectedMedia['type'],
             'media_id' => $selectedMedia['media_id'],
             'name' => $selectedMedia['name'],
             'cover' => $selectedMedia['cover'],
@@ -88,7 +88,7 @@ class Edit extends Component
         $this->phrase = '';
         $this->searchedMedia = [];
 
-        Flux::toast(variant: 'success', text: "{$media->type->name} added!", duration: 3000);
+        Flux::toast(variant: 'success', text: "{$media->type->label()} added!", duration: 3000);
     }
 
     public function destroy($id)
@@ -97,7 +97,7 @@ class Edit extends Component
 
         $media->delete();
 
-        Flux::toast(variant: 'success', text: "{$media->type->name} deleted.", duration: 3000);
+        Flux::toast(variant: 'success', text: "{$media->type->label()} deleted.", duration: 3000);
     }
 
     public function resetSearch()

--- a/app/Livewire/Media/Music/Show.php
+++ b/app/Livewire/Media/Music/Show.php
@@ -18,10 +18,10 @@ class Show extends Component
     {
         return view('livewire.pages.media.music.show', [
             'favoriteArtists' => Media::query()
-                ->where('type_id', MediaType::ARTIST->value)
+                ->where('type', MediaType::ARTIST->value)
                 ->paginate(20, pageName: 'artists'),
             'favoriteTracks' => Media::query()
-                ->where('type_id', MediaType::TRACK->value)
+                ->where('type', MediaType::TRACK->value)
                 ->paginate(9, pageName: 'tracks'),
             'panel' => Panel::where('name', 'music')->first()->content,
         ]);

--- a/app/Livewire/Media/Tv/Edit.php
+++ b/app/Livewire/Media/Tv/Edit.php
@@ -38,7 +38,7 @@ class Edit extends Component
     public function medias()
     {
         return Media::query()
-            ->where('type_id', MediaType::TV->value)
+            ->where('type', MediaType::TV->value)
             ->when($this->search != '', fn (Builder $query) => $query->where('name', 'LIKE', "%$this->search%"))
             ->tap(fn ($query) => $this->sortBy ? $query->orderBy($this->sortBy, $this->sortDirection) : $query)
             ->paginate($this->perPage);

--- a/app/Livewire/Media/Tv/Show.php
+++ b/app/Livewire/Media/Tv/Show.php
@@ -18,19 +18,19 @@ class Show extends Component
     {
         return view('livewire.pages.media.tv.show', [
             'favorites' => Media::query()
-                ->where('type_id', MediaType::TV->value)
+                ->where('type', MediaType::TV->value)
                 ->where('is_favorite', true)
                 ->paginate(27, pageName: 'favorites'),
             'current' => Media::query()
-                ->where('type_id', MediaType::TV->value)
+                ->where('type', MediaType::TV->value)
                 ->where('is_active', true)
                 ->paginate(27, pageName: 'currentlyWatching'),
             'backlog' => Media::query()
-                ->where('type_id', MediaType::TV->value)
+                ->where('type', MediaType::TV->value)
                 ->where('in_backlog', true)
                 ->paginate(27, pageName: 'backlog'),
             'completed' => Media::query()
-                ->where('type_id', MediaType::TV->value)
+                ->where('type', MediaType::TV->value)
                 ->where('is_completed', true)
                 ->paginate(27, pageName: 'completed'),
             'panel' => Panel::where('name', 'tv')->first()->content,

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -2,13 +2,13 @@
 
 namespace App\Models;
 
-use App\Models\Model;
+use App\Enums\MediaType;
 use Illuminate\Contracts\Database\Query\Builder;
 
 class Media extends Model
 {
     protected $fillable = [
-        'type_id',
+        'type',
         'media_id',
         'name',
         'cover',
@@ -29,6 +29,7 @@ class Media extends Model
     public function casts(): array
     {
         return [
+            'type' => MediaType::class,
             'is_favorite' => 'boolean',
             'is_active' => 'boolean',
             'in_backlog' => 'boolean',

--- a/database/factories/MediaFactory.php
+++ b/database/factories/MediaFactory.php
@@ -17,7 +17,7 @@ class MediaFactory extends Factory
     public function definition(): array
     {
         return [
-            'type_id' => MediaType::VIDEO_GAME->value,
+            'type' => MediaType::VIDEO_GAME->value,
             'media_id' => (string) $this->faker->unique()->numberBetween(1, 1_000_000),
             'name' => $this->faker->words(3, true),
             'cover' => $this->faker->imageUrl(),
@@ -31,16 +31,16 @@ class MediaFactory extends Factory
 
     public function videoGame(): static
     {
-        return $this->state(fn () => ['type_id' => MediaType::VIDEO_GAME->value]);
+        return $this->state(fn () => ['type' => MediaType::VIDEO_GAME->value]);
     }
 
     public function movie(): static
     {
-        return $this->state(fn () => ['type_id' => MediaType::MOVIE->value]);
+        return $this->state(fn () => ['type' => MediaType::MOVIE->value]);
     }
 
     public function tv(): static
     {
-        return $this->state(fn () => ['type_id' => MediaType::TV->value]);
+        return $this->state(fn () => ['type' => MediaType::TV->value]);
     }
 }

--- a/database/migrations/2026_06_09_023533_rename_media_type_id_to_type.php
+++ b/database/migrations/2026_06_09_023533_rename_media_type_id_to_type.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Enums\MediaType;
+use App\Models\Media;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('media', function (Blueprint $table) {
+            $table->renameColumn('type_id', 'type');
+        });
+
+        Schema::table('media', function (Blueprint $table) {
+            $table->string('type')->change();
+        });
+
+        $map = [
+            1 => MediaType::MOVIE->value,
+            2 => MediaType::TV->value,
+            3 => MediaType::ARTIST->value,
+            4 => MediaType::TRACK->value,
+            5 => MediaType::VIDEO_GAME->value,
+        ];
+
+        DB::transaction(function () use ($map): void {
+            foreach ($map as $old => $new) {
+                Media::withoutGlobalScopes()->where('type', (string) $old)->update(['type' => $new]);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        $map = [
+            MediaType::MOVIE->value => 1,
+            MediaType::TV->value => 2,
+            MediaType::ARTIST->value => 3,
+            MediaType::TRACK->value => 4,
+            MediaType::VIDEO_GAME->value => 5,
+        ];
+
+        DB::transaction(function () use ($map): void {
+            foreach ($map as $old => $new) {
+                Media::withoutGlobalScopes()->where('type', $old)->update(['type' => $new]);
+            }
+        });
+
+        Schema::table('media', function (Blueprint $table) {
+            $table->unsignedBigInteger('type')->change();
+        });
+
+        Schema::table('media', function (Blueprint $table) {
+            $table->renameColumn('type', 'type_id');
+        });
+    }
+};

--- a/tests/Feature/Livewire/Media/GamesEditTest.php
+++ b/tests/Feature/Livewire/Media/GamesEditTest.php
@@ -49,10 +49,10 @@ it('rejects unknown state names', function () {
     $game = Media::factory()->videoGame()->create();
 
     Livewire::test(Edit::class)
-        ->call('toggleState', $game->getKey(), 'type_id')
+        ->call('toggleState', $game->getKey(), 'type')
         ->assertStatus(422);
 
-    expect($game->fresh()->type_id)->toBe(MediaType::VIDEO_GAME->value);
+    expect($game->fresh()->type)->toBe(MediaType::VIDEO_GAME);
 });
 
 it('destroys a game', function () {

--- a/tests/Feature/Livewire/Media/MoviesEditTest.php
+++ b/tests/Feature/Livewire/Media/MoviesEditTest.php
@@ -31,7 +31,7 @@ it('rejects states that are not toggleable for movies', function (string $value)
     Livewire::test(Edit::class)
         ->call('toggleState', $movie->getKey(), $value)
         ->assertStatus(422);
-})->with(['is_active', 'total_completion', 'type_id']);
+})->with(['is_active', 'total_completion', 'type']);
 
 it('destroys a movie', function () {
     $movie = Media::factory()->movie()->create();

--- a/tests/Feature/Livewire/Media/TvEditTest.php
+++ b/tests/Feature/Livewire/Media/TvEditTest.php
@@ -32,4 +32,4 @@ it('rejects states that are not toggleable for tv shows', function (string $valu
     Livewire::test(Edit::class)
         ->call('toggleState', $show->getKey(), $value)
         ->assertStatus(422);
-})->with(['total_completion', 'type_id']);
+})->with(['total_completion', 'type']);


### PR DESCRIPTION
Renames the `media.type_id` column to `media.type` and converts it to a string type, aligning with the `MediaType` enum which is now string-backed.

This change enhances type safety, improves database readability with descriptive string values (e.g., 'movie' instead of '1'), and leverages Laravel's enum casting. It also resolves display issues in views by utilizing the `label()` method of the enum.