### PR TITLE
refactor(enums): Convert Asset and Connection types to string-backed …

### DIFF
--- a/app/Actions/Api/Spotify/RefreshToken.php
+++ b/app/Actions/Api/Spotify/RefreshToken.php
@@ -13,7 +13,7 @@ final class RefreshToken
     public function handle(User $user): bool
     {
         try {
-            $spotifyConnection = $user->connections->firstWhere('type_id', ConnectionType::SPOTIFY->value);
+            $spotifyConnection = $user->connections->firstWhere('type', ConnectionType::SPOTIFY->value);
 
             $response = Http::asForm()->post('https://accounts.spotify.com/api/token', [
                 'grant_type' => 'refresh_token',

--- a/app/Actions/Api/Spotify/SearchArtist.php
+++ b/app/Actions/Api/Spotify/SearchArtist.php
@@ -15,7 +15,7 @@ final class SearchArtist
         (new RefreshToken)->handle($user);
 
         $response = Http::withHeaders([
-            'Authorization' => 'Bearer '.$user->connections->firstWhere('type_id', ConnectionType::SPOTIFY->value)->token,
+            'Authorization' => 'Bearer '.$user->connections->firstWhere('type', ConnectionType::SPOTIFY->value)->token,
             'Content-Type' => 'application/json',
             'Client-Id' => config('services.spotify.client_id'),
         ])->get('https://api.spotify.com/v1/search', [

--- a/app/Actions/Api/Spotify/SearchTrack.php
+++ b/app/Actions/Api/Spotify/SearchTrack.php
@@ -16,7 +16,7 @@ final class SearchTrack
         (new RefreshToken)->handle($user);
 
         $response = Http::withHeaders([
-            'Authorization' => 'Bearer '.$user->connections->firstWhere('type_id', ConnectionType::SPOTIFY->value)->token,
+            'Authorization' => 'Bearer '.$user->connections->firstWhere('type', ConnectionType::SPOTIFY->value)->token,
             'Content-Type' => 'application/json',
             'Client-Id' => config('services.spotify.client_id'),
         ])->get('https://api.spotify.com/v1/search', [

--- a/app/Actions/Api/Twitch/RefreshToken.php
+++ b/app/Actions/Api/Twitch/RefreshToken.php
@@ -13,7 +13,7 @@ final class RefreshToken
     public function handle(User $user): bool
     {
         try {
-            $twitchConnection = $user->connections->firstWhere('type_id', ConnectionType::TWITCH->value);
+            $twitchConnection = $user->connections->firstWhere('type', ConnectionType::TWITCH->value);
 
             $response = Http::asForm()->post('https://id.twitch.tv/oauth2/token', [
                 'client_id' => config('services.twitch.client_id'),

--- a/app/Actions/Api/Twitch/SearchCategories.php
+++ b/app/Actions/Api/Twitch/SearchCategories.php
@@ -15,7 +15,7 @@ final class SearchCategories
         (new RefreshToken)->handle($user);
 
         $response = Http::withHeaders([
-            'Authorization' => 'Bearer '.$user->connections->firstWhere('type_id', ConnectionType::TWITCH->value)->token,
+            'Authorization' => 'Bearer '.$user->connections->firstWhere('type', ConnectionType::TWITCH->value)->token,
             'Content-Type' => 'application/json',
             'Client-Id' => config('services.twitch.client_id'),
         ])->get('https://api.twitch.tv/helix/search/categories', [

--- a/app/Console/Commands/CheckTwitchLiveStatus.php
+++ b/app/Console/Commands/CheckTwitchLiveStatus.php
@@ -22,7 +22,7 @@ class CheckTwitchLiveStatus extends Command
 
         (new RefreshToken)->handle($user);
 
-        $token = $user->connections->firstWhere('type_id', ConnectionType::TWITCH->value)->token ?? null;
+        $token = $user->connections->firstWhere('type', ConnectionType::TWITCH->value)->token ?? null;
 
         if (! $token) {
             return self::FAILURE;

--- a/app/Console/Commands/UpdateArtistImages.php
+++ b/app/Console/Commands/UpdateArtistImages.php
@@ -34,7 +34,7 @@ class UpdateArtistImages extends Command
                     'GET',
                     "https://api.spotify.com/v1/artists?ids={$ids}", [
                         'headers' => [
-                            'Authorization' => 'Bearer '.$user->connections->firstWhere('type_id', ConnectionType::SPOTIFY->value)->token,
+                            'Authorization' => 'Bearer '.$user->connections->firstWhere('type', ConnectionType::SPOTIFY->value)->token,
                         ],
                     ]
                 );

--- a/app/Enums/AssetType.php
+++ b/app/Enums/AssetType.php
@@ -2,11 +2,11 @@
 
 namespace App\Enums;
 
-enum AssetType: int
+enum AssetType: string
 {
-    case PHOTO = 1;
-    case RESUME = 2;
-    case THREE_D_PRINTS = 3;
+    case PHOTO = 'photo';
+    case RESUME = 'resume';
+    case THREE_D_PRINTS = 'three_d_prints';
 
     public function label(): string
     {

--- a/app/Enums/ConnectionType.php
+++ b/app/Enums/ConnectionType.php
@@ -2,24 +2,16 @@
 
 namespace App\Enums;
 
-enum ConnectionType: int
+enum ConnectionType: string
 {
-    case SPOTIFY = 1;
-    case TWITCH = 2;
+    case SPOTIFY = 'spotify';
+    case TWITCH = 'twitch';
 
-    public function label()
+    public function label(): string
     {
-        return match($this) {
+        return match ($this) {
             self::SPOTIFY => 'Spotify',
             self::TWITCH => 'Twitch',
-        };
-    }
-
-    public function slug()
-    {
-        return match($this) {
-            self::SPOTIFY => 'spotify',
-            self::TWITCH => 'twitch',
         };
     }
 }

--- a/app/Http/Controllers/ConnectionController.php
+++ b/app/Http/Controllers/ConnectionController.php
@@ -10,34 +10,28 @@ class ConnectionController extends Controller
 {
     public function connect(Request $request, string $type)
     {
-        session()->put('current_connection_type_id', $this->getConnectionTypeId($type));
-        session()->put('current_connection_type', $type);
+        $connectionType = ConnectionType::from($type);
 
-        return Socialite::driver($type)->redirect();
+        session()->put('current_connection_type', $connectionType->value);
+
+        return Socialite::driver($connectionType->value)->redirect();
     }
 
     public function processConnection(Request $request)
     {
-        $user = Socialite::driver(session()->get('current_connection_type'))->stateless()->user();
+        $type = session()->get('current_connection_type');
 
-        auth()->user()->connections()->updateOrCreate(['type_id' => session()->get('current_connection_type_id')], [
-            'type_id' => session()->get('current_connection_type_id'),
+        $user = Socialite::driver($type)->stateless()->user();
+
+        auth()->user()->connections()->updateOrCreate(['type' => $type], [
+            'type' => $type,
             'external_id' => $user->id,
             'token' => $user->token,
             'refresh_token' => $user->refreshToken,
         ]);
 
-        session()->forget('current_connection_type_id');
         session()->forget('current_connection_type');
 
         return redirect(route('dashboard'));
-    }
-
-    private function getConnectionTypeId(string $type)
-    {
-        return match ($type) {
-            'twitch' => ConnectionType::TWITCH->slug(),
-            'spotify' => ConnectionType::SPOTIFY->slug()
-        };
     }
 }

--- a/app/Livewire/Forms/PhotoForm.php
+++ b/app/Livewire/Forms/PhotoForm.php
@@ -20,7 +20,7 @@ class PhotoForm extends Form
 
     public string $description = '';
 
-    public int $type = AssetType::PHOTO->value;
+    public string $type = AssetType::PHOTO->value;
 
     public $photo;
 
@@ -37,7 +37,7 @@ class PhotoForm extends Form
         );
 
         Asset::create([
-            'type_id' => $this->type,
+            'type' => $this->type,
             'name' => $this->name,
             'slug' => Str::uuid(),
             'path' => $path,
@@ -100,7 +100,7 @@ class PhotoForm extends Form
             'description' => 'nullable|string|max:255',
             'type' => [
                 'required',
-                'integer',
+                'string',
                 Rule::in([AssetType::PHOTO->value, AssetType::THREE_D_PRINTS->value]),
             ],
             'photo' => 'image:mimes:png,jpg,jpeg,gif,jfif',

--- a/app/Livewire/Navigation.php
+++ b/app/Livewire/Navigation.php
@@ -14,7 +14,7 @@ class Navigation extends Component
     {
         return view('navigation', [
             'resume' => Asset::query()
-                ->where('type_id', AssetType::RESUME->value)
+                ->where('type', AssetType::RESUME->value)
                 ->latest()
                 ->first()?->slug,
         ]);

--- a/app/Livewire/Photos/Gallery.php
+++ b/app/Livewire/Photos/Gallery.php
@@ -18,7 +18,7 @@ class Gallery extends Component
 
     public string $emptyMessage = 'No Photos';
 
-    public array|int $type = AssetType::PHOTO->value;
+    public array|string $type = AssetType::PHOTO->value;
 
     public PhotoForm $form;
 
@@ -32,7 +32,7 @@ class Gallery extends Component
     public function photos()
     {
         return Asset::query()
-            ->whereIn('type_id', is_array($this->type) ? $this->type : [$this->type])
+            ->whereIn('type', is_array($this->type) ? $this->type : [$this->type])
             ->paginate(9);
     }
 

--- a/app/Livewire/Photos/Uploader.php
+++ b/app/Livewire/Photos/Uploader.php
@@ -17,7 +17,7 @@ class Uploader extends Component
 
     public bool $showGallery = true;
 
-    public array|int $galleryType = AssetType::PHOTO->value;
+    public array|string $galleryType = AssetType::PHOTO->value;
 
     public function render()
     {

--- a/app/Livewire/Resume.php
+++ b/app/Livewire/Resume.php
@@ -34,7 +34,7 @@ class Resume extends Component
         $path = $this->resume->storePubliclyAs('resumes', $name, 's3');
 
         Asset::create([
-            'type_id' => AssetType::RESUME->value,
+            'type' => AssetType::RESUME->value,
             'slug' => Str::uuid(),
             'name' => $name,
             'path' => $path,
@@ -62,6 +62,6 @@ class Resume extends Component
     #[Computed]
     public function resumes()
     {
-        return Asset::where('type_id', AssetType::RESUME->value)->get();
+        return Asset::where('type', AssetType::RESUME->value)->get();
     }
 }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 class Asset extends Model
 {
     protected $fillable = [
-        'type_id',
+        'type',
         'name',
         'slug',
         'path',
@@ -27,7 +27,7 @@ class Asset extends Model
     public function casts(): array
     {
         return [
-            'type_id' => AssetType::class,
+            'type' => AssetType::class,
             'data' => 'array',
         ];
     }

--- a/app/Models/Connection.php
+++ b/app/Models/Connection.php
@@ -3,13 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Connection extends Model
 {
     protected $fillable = [
         'external_id',
-        'type_id',
+        'type',
         'name',
         'token',
         'refresh_token',

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -22,7 +22,7 @@ class AssetFactory extends Factory
         $name = $this->faker->words(3, true);
 
         return [
-            'type_id' => $this->faker->randomElement([AssetType::PHOTO->value, AssetType::RESUME->value]),
+            'type' => $this->faker->randomElement([AssetType::PHOTO->value, AssetType::RESUME->value]),
             'name' => $name,
             'slug' => Str::slug($name),
             'path' => $this->faker->filePath(),
@@ -41,7 +41,7 @@ class AssetFactory extends Factory
     public function photo(): static
     {
         return $this->state(fn (array $attributes) => [
-            'type_id' => AssetType::PHOTO->value,
+            'type' => AssetType::PHOTO->value,
             'mime_type' => $this->faker->randomElement([
                 'image/jpeg',
                 'image/png',
@@ -59,7 +59,7 @@ class AssetFactory extends Factory
     public function resume(): static
     {
         return $this->state(fn (array $attributes) => [
-            'type_id' => AssetType::RESUME->value,
+            'type' => AssetType::RESUME->value,
             'mime_type' => $this->faker->randomElement([
                 'application/pdf',
             ]),

--- a/database/migrations/2026_06_09_031112_rename_connections_type_id_to_type.php
+++ b/database/migrations/2026_06_09_031112_rename_connections_type_id_to_type.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('connections', function (Blueprint $table) {
+            $table->renameColumn('type_id', 'type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('connections', function (Blueprint $table) {
+            $table->renameColumn('type', 'type_id');
+        });
+    }
+};

--- a/database/migrations/2026_06_09_031113_rename_assets_type_id_to_type.php
+++ b/database/migrations/2026_06_09_031113_rename_assets_type_id_to_type.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Enums\AssetType;
+use App\Models\Asset;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->renameColumn('type_id', 'type');
+        });
+
+        Schema::table('assets', function (Blueprint $table) {
+            $table->string('type')->change();
+        });
+
+        $map = [
+            1 => AssetType::PHOTO->value,
+            2 => AssetType::RESUME->value,
+            3 => AssetType::THREE_D_PRINTS->value,
+        ];
+
+        DB::transaction(function () use ($map): void {
+            foreach ($map as $old => $new) {
+                Asset::withoutGlobalScopes()->where('type', (string) $old)->update(['type' => $new]);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        $map = [
+            AssetType::PHOTO->value => 1,
+            AssetType::RESUME->value => 2,
+            AssetType::THREE_D_PRINTS->value => 3,
+        ];
+
+        DB::transaction(function () use ($map): void {
+            foreach ($map as $old => $new) {
+                Asset::withoutGlobalScopes()->where('type', $old)->update(['type' => $new]);
+            }
+        });
+
+        Schema::table('assets', function (Blueprint $table) {
+            $table->integer('type')->change();
+        });
+
+        Schema::table('assets', function (Blueprint $table) {
+            $table->renameColumn('type', 'type_id');
+        });
+    }
+};

--- a/resources/views/livewire/connection.blade.php
+++ b/resources/views/livewire/connection.blade.php
@@ -4,13 +4,13 @@
     @php
         $connections = [
             'spotify' => [
-                'connection' => auth()->user()->connections->firstWhere('type_id', App\Enums\ConnectionType::SPOTIFY->value),
+                'connection' => auth()->user()->connections->firstWhere('type', App\Enums\ConnectionType::SPOTIFY->value),
                 'icon' => 'musical-note',
                 'color' => 'lime',
                 'name' => 'Spotify'
             ],
             'twitch' => [
-                'connection' => auth()->user()->connections->firstWhere('type_id', App\Enums\ConnectionType::TWITCH->value),
+                'connection' => auth()->user()->connections->firstWhere('type', App\Enums\ConnectionType::TWITCH->value),
                 'icon' => 'tv',
                 'color' => 'purple', 
                 'name' => 'Twitch'

--- a/resources/views/livewire/pages/media/games/show.blade.php
+++ b/resources/views/livewire/pages/media/games/show.blade.php
@@ -28,7 +28,7 @@
                 />
                 <x-media-accordian-item
                     :collection="$playedBefore"
-                    :title="'Played Before'"
+                    :title="'Catalog'"
                 />
                 <x-media-accordian-item
                     :collection="$completed"

--- a/resources/views/livewire/pages/media/music/edit.blade.php
+++ b/resources/views/livewire/pages/media/music/edit.blade.php
@@ -156,7 +156,7 @@
             <flux:button
                 type="submit"
                 icon="magnifying-glass"
-                wire:click="searchSpotify({{ MediaType::ARTIST  }})"
+                wire:click="searchSpotify('{{ MediaType::ARTIST  }}')"
             />
         </flux:input.group>
 
@@ -196,7 +196,7 @@
         <flux:input.group>
             <flux:input wire:model="phrase" placeholder="Search..." required />
 
-            <flux:button type="submit" icon="magnifying-glass" wire:click="searchSpotify({{ MediaType::TRACK }})" />
+            <flux:button type="submit" icon="magnifying-glass" wire:click="searchSpotify('{{ MediaType::TRACK }}')" />
         </flux:input.group>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
…enums

Updates `AssetType` and `ConnectionType` enums to use string values instead of integers.

This involves renaming `type_id` columns to `type` in the `assets` and `connections` tables, along with a data migration to convert existing integer values to their new string representations.

The change enhances readability, improves type safety, and simplifies related logic by leveraging native Laravel string-backed enum casting.