### PR TITLE
Run on PHP 8.5

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
       with:
-        php-version: '8.4'
+        php-version: '8.5'
         tools: composer:v2
 
     - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.4",
+        "php": "^8.5",
         "intervention/image": "^3.11",
-        "kyledoesdev/essentials": "^0.0.7",
+        "kyledoesdev/essentials": "^0.0.8",
         "laravel/framework": "^13.0",
         "laravel/nightwatch": "^1.8",
         "laravel/socialite": "^5.18",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "382d9bbeb35740c223d00c6145ebefe5",
+    "content-hash": "5ea1baf1de800b75ef02155883024748",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1420,23 +1420,23 @@
         },
         {
             "name": "kyledoesdev/essentials",
-            "version": "v0.0.7",
+            "version": "v0.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kyledoesdev/essentials.git",
-                "reference": "432041c5e4a7c0113c7252185bc4bc332324c1c3"
+                "reference": "40279f82e30cfa95c972f8aba805904fa255b114"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kyledoesdev/essentials/zipball/432041c5e4a7c0113c7252185bc4bc332324c1c3",
-                "reference": "432041c5e4a7c0113c7252185bc4bc332324c1c3",
+                "url": "https://api.github.com/repos/kyledoesdev/essentials/zipball/40279f82e30cfa95c972f8aba805904fa255b114",
+                "reference": "40279f82e30cfa95c972f8aba805904fa255b114",
                 "shasum": ""
             },
             "require": {
                 "illuminate/contracts": "^12.0|^13.0",
                 "illuminate/http": "^12.0|^13.0",
                 "illuminate/support": "^12.0|^13.0",
-                "php": "^8.4",
+                "php": "^8.4|^8.5",
                 "spatie/laravel-package-tools": "^1.16",
                 "spatie/laravel-stats": "^2.3"
             },
@@ -1488,9 +1488,9 @@
             ],
             "support": {
                 "issues": "https://github.com/kyledoesdev/essentials/issues",
-                "source": "https://github.com/kyledoesdev/essentials/tree/v0.0.7"
+                "source": "https://github.com/kyledoesdev/essentials/tree/v0.0.8"
             },
-            "time": "2026-04-24T22:56:10+00:00"
+            "time": "2026-07-15T14:24:29+00:00"
         },
         {
             "name": "laravel/framework",
@@ -12368,7 +12368,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use Pdo\Mysql;
 
 return [
 
@@ -64,7 +65,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -84,7 +85,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
Hard cutover of the platform's PHP requirement to **8.5**.

> ⚠️ **Stacked on #chore/laravel-13** — this PR targets the `chore/laravel-13` branch so the diff shows only the PHP 8.5 commit. Merge the Laravel 13 PR first; GitHub will then auto-retarget this PR to `master`.

No dependency blocked 8.5 — `composer why-not php 8.5.0` was clean; every constraint already admitted it. `kyledoesdev/essentials` 0.0.8 declares `php: ^8.4|^8.5`.

### composer.json
- `php` ^8.4 → ^8.5
- `kyledoesdev/essentials` ^0.0.7 → ^0.0.8

### Code
- `config/database.php`: `PDO::MYSQL_ATTR_SSL_CA` (deprecated in PHP 8.5) → namespaced `Pdo\Mysql::ATTR_SSL_CA` on the mysql + mariadb connections

### CI
- Workflow PHP 8.4 → 8.5

### Verification (run natively on PHP 8.5.8 via Herd)
- ✅ `composer update` resolves clean · `composer audit` clean
- ✅ 27 Pest tests pass, no deprecation output
- ✅ `npm run build` succeeds
- ✅ `artisan about` → PHP 8.5.8 / Laravel 13.20.0

### Deploy note (Forge)
Provision PHP 8.5 (CLI + FPM) with extension parity to the 8.4 build — `ext-json`, gd/imagick, curl, openssl, mbstring — repoint the site + deploy pipeline, restart FPM/queue workers/Nightwatch. Deploy only after CI is green on 8.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)