### PR TITLE
feat: introduce Bean Bot for daily drink messages

### DIFF
--- a/app/Console/Commands/SendDailyCoffeeMessage.php
+++ b/app/Console/Commands/SendDailyCoffeeMessage.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+class SendDailyCoffeeMessage extends Command
+{
+    protected $signature = 'royal-tea:send';
+
+    protected $description = 'Send the daily coffee message to Discord';
+
+    /**
+     * @var array<int, string>
+     */
+    private const array DRINKS = [
+        'Espresso',
+        'Americano',
+        'Latte',
+        'Cappuccino',
+        'Flat White',
+        'Cortado',
+        'Macchiato',
+        'Caramel Macchiato',
+        'Mocha',
+        'Affogato',
+        'Cold Brew',
+        'Nitro Cold Brew',
+        'Iced Latte',
+        'Frappé',
+        'French Press',
+        'Turkish Coffee',
+        'Vietnamese Iced Coffee',
+        'Irish Coffee',
+        'Drip Coffee',
+        'Matcha Latte',
+        "Earl Grey Tea",
+        "Jasmine Tea",
+        "Hōjicha",
+        "Hot Chocolate",
+        "Pumpkin Spice Latte",
+        "Charlie Drink",
+        "Espresso Martini",
+        "Mimosa",
+        "Bloody Mary",
+    ];
+
+    public function handle(): int
+    {
+        $drink = $this->getRandomDrink();
+
+        $response = Http::post(config('services.royal-tea.webhook_url'), [
+            'content' => "Your daily drink is here! Scroll up for your {$drink} - get to sippin!",
+        ]);
+
+        if ($response->failed()) {
+            $this->error("Failed to send the daily {$drink} to Discord.");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Daily coffee message sent! Today's drink: {$drink}.");
+
+        return self::SUCCESS;
+    }
+
+    private function getRandomDrink(): string
+    {
+        return collect(self::DRINKS)->random();
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -49,4 +49,8 @@ return [
         'internal_updates' => env('DISCORD_INTERNAL_UPDATES'),
         'live_now' => env('DISCORD_LIVE_NOW'),
     ],
+
+    'royal-tea' => [
+        'webhook_url' => env('ROYALTY_WEBHOOK_URL'),
+    ]
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,6 +1,11 @@
 <?php
 
 use App\Console\Commands\CheckTwitchLiveStatus;
+use App\Console\Commands\SendDailyCoffeeMessage;
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command(CheckTwitchLiveStatus::class)->everyFiveMinutes();
+
+Schedule::command(SendDailyCoffeeMessage::class)
+    ->dailyAt('10:00')
+    ->timezone('America/New_York');


### PR DESCRIPTION
Adds a new scheduled command (`royal-tea:send`) that sends a reminder to listen to the beans.

This command is scheduled to run daily at 10:00 AM America/New_York time and its target webhook URL is configured via the `ROYALTY_WEBHOOK_URL` environment variable.